### PR TITLE
Implemented a simple search option

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1,5 +1,5 @@
 '''
-    Uitzendinggemist(NPO)
+    Uitzending Gemist(NPO)
     ~~~~~~~
 
     An XBMC addon for watching uzg 
@@ -9,63 +9,97 @@
     Uitzendinggemist(NPO) / uzg = Made by Bas Magre (Opvolger)
     
 '''
+
 from xbmcswift2 import Plugin, SortMethod
 import resources.lib.uzg
 import time
-import xbmcplugin
+import xbmc
+import xbmcgui
 
 PLUGIN_NAME = 'uzg'
 PLUGIN_ID = 'plugin.video.uzg'
 plugin = Plugin(PLUGIN_NAME, PLUGIN_ID, __file__)
 
 uzg = resources.lib.uzg.Uzg()
-subtitle = plugin.get_setting( "subtitle", bool )
+subtitle = plugin.get_setting("subtitle", bool)
+
 
 @plugin.route('/')
 def index():
-    ##main, alle shows
+    return [
+        {
+            'path': plugin.url_for('series'),
+            'label': 'Alle series',
+        },
+        {
+            'path': plugin.url_for('zoek'),
+            'label': 'Zoek',
+        }
+    ]
+
+
+@plugin.route('/zoek/')
+def zoek():
+    dialog = xbmcgui.Dialog()
+    d = dialog.input('Op welke serie wilt u zoeken?', type=xbmcgui.INPUT_ALPHANUM)
     items = [{
         'path': plugin.url_for('show_afleveringen', nebo_id=item['nebo_id']),
         'label': item['label'],
         'thumbnail': item['thumbnail'],
-    } for item in uzg.get_overzicht()]    
+    } for item in uzg.get_overzicht()]
+    items = [e for e in items if d in e['label']]
     return items
+
+
+@plugin.route('/series/')
+def series():
+    # main, alle shows
+    items = [{
+        'path': plugin.url_for('show_afleveringen', nebo_id=item['nebo_id']),
+        'label': item['label'],
+        'thumbnail': item['thumbnail'],
+    } for item in uzg.get_overzicht()]
+    return items
+
 
 @plugin.route('/afleveringen/<nebo_id>/')
 def show_afleveringen(nebo_id):
     return show_items(uzg.get_items(nebo_id))
 
+
 @plugin.route('/lectures/<whatson_id>/')
 def play_lecture(whatson_id):
-	plugin.set_resolved_url(uzg.get_play_url(whatson_id))	
-	if (subtitle):
-		add_subtitlesstream(uzg.get_ondertitel(whatson_id))
+    plugin.set_resolved_url(uzg.get_play_url(whatson_id))
+    if subtitle:
+        add_subtitlesstream(uzg.get_ondertitel(whatson_id))
+
 
 def add_subtitlesstream(subtitles):
-	player = xbmc.Player()
-	for _ in xrange(30):
-		if player.isPlaying():
-			break
-		time.sleep(1)
-	else:
-		raise Exception('No video playing. Aborted after 30 seconds.')
-	player.setSubtitles(subtitles)
-	player.setSubtitleStream(1)
+    player = xbmc.Player()
+    for _ in range(30):
+        if player.isPlaying():
+            break
+        time.sleep(1)
+    else:
+        raise Exception('No video playing. Aborted after 30 seconds.')
+    player.setSubtitles(subtitles)
+    player.setSubtitleStream(1)
 
-	
+
 def show_items(opgehaaldeitemsclass):
-    '''Lists playable videos for a given category url.'''
+    # Lists playable videos for a given category url.
     items = [{
         'path': plugin.url_for('play_lecture', whatson_id=item['whatson_id']),
-        ##'whatson_id': item['whatson_id'],
+        # 'whatson_id': item['whatson_id'],
         'label': item['label'],
         'thumbnail': item['thumbnail'],
         'is_playable': True,
         'info': {
-                'date': item['date']
+            'date': item['date']
         },
     } for item in opgehaaldeitemsclass]
     return plugin.finish(items,sort_methods=[SortMethod.DATE,SortMethod.LABEL])
+
 
 if __name__ == '__main__':
     plugin.run()

--- a/addon.py
+++ b/addon.py
@@ -47,7 +47,7 @@ def zoek():
         'label': item['label'],
         'thumbnail': item['thumbnail'],
     } for item in uzg.get_overzicht()]
-    items = [e for e in items if d in e['label']]
+    items = [e for e in items if d.lower() in e['label'].lower()]
     return items
 
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.uzg" name="Uitzendinggemist (NPO)" provider-name="Bas Magré (Opvolger)" version="1.2.0">
+<addon id="plugin.video.uzg" name="Uitzending Gemist (NPO)" provider-name="Bas Magré (Opvolger)" version="1.3.0">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />
     <import addon="script.module.xbmcswift2" version="2.4.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,19 +1,22 @@
-﻿﻿﻿﻿﻿﻿﻿Version 1.2.0
+Version 1.3.0
+* Added search functionality
+
+Version 1.2.0
 * Refactor code.
 
 Version 1.1.0
 * Subtitle added
 
-﻿﻿﻿Version 1.0.6
+Version 1.0.6
 * New API NPO
 
-﻿﻿﻿Version 1.0.5
-* little fixxen for official repo requirements
+Version 1.0.5
+* little fixes for official repo requirements
 
 Version 1.0.4
 * Description changed
 
-﻿﻿Version 1.0.3
+Version 1.0.3
 * icon changed
 
 Version 1.0.2


### PR DESCRIPTION
I've implemented a simple search option. This is very useful, because in this way the user does not have to scroll through a massive list of items. I also changed the title of the addon, this now matches [www.npo.nl/uitzending-gemist](http://www.npo.nl/uitzending-gemist). The code in `addon.py` is now more in contract with the [PEP 8 style guide](https://www.python.org/dev/peps/pep-0008/). Maybe you can add icons to `Alle series` and `Zoek` functionality, I wasn't able to :cry:. I don't know how to use the language files yet, maybe you can teach me :smile:?
