### PR TITLE
kleine enhancements

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -87,7 +87,7 @@ def list_franchise(link):
         add_video_items(episodesOrseason['items'])
         # next 20 afleveringen
         if (episodesOrseason['linknext'] is not None):
-            list_item = xbmcgui.ListItem(label='. -- MORE -- .') # TODO deze moet in language file
+            list_item = xbmcgui.ListItem(label='[  Volgende pagina  ]') # TODO deze moet in language file
             list_item.setProperty('IsPlayable', 'false')
             url = get_url(action='episodes', link=episodesOrseason['linknext'])
             is_folder = True

--- a/addon.py
+++ b/addon.py
@@ -79,7 +79,8 @@ def list_letter(letter):
 
 def list_franchise(link):
     xbmcplugin.setPluginCategory(_handle, link)
-    xbmcplugin.setContent(_handle, 'videos')
+    #enable media info viewtype zodat "plot" van een aflevering ook getoond kan worden (indien gewenst)
+    xbmcplugin.setContent(_handle, 'movies')
     episodesOrseason = uzg.episodesOrseason(link)
     if (episodesOrseason['type'] == 'episodes'):
         # het zijn gelijk afleveringen, pak de items en voeg deze toe!

--- a/resources/lib/uzg.py
+++ b/resources/lib/uzg.py
@@ -129,6 +129,18 @@ class Uzg:
                     thumbnail = item['images']['original']['formats']['tv']['source']
             return thumbnail
 
+        def __geteptitle(self, item):
+            eptitle = ''
+            if item['episodeTitle']:
+                    eptitle = item['episodeTitle']
+            return eptitle
+
+        def __getepdetail(self, item):
+            epdetail = ''
+            if item['images']:
+                    epdetail = item['images']['grid.tile']['alt']
+            return epdetail
+
         def __getgenres(self, item):
             genres = ''
             if item['genres']:
@@ -148,11 +160,11 @@ class Uzg:
                                         'icon':  self.__getimage(episode),
                                         'fanart':  self.__getimage(episode) }
                             , 'video': {
-                                        'title': episode['title'],
+                                        'title': self.__geteptitle(episode) ,
                                         'premiered': datum,
                                         'aired': datum,
                                         'date': self.__dateitem(datum),
-                                        'plot': episode['descriptionLong'],
+                                        'plot': self.__getepdetail(episode),
                                         'studio': ', '.join(episode['broadcasters']),
                                         'year': datum.split('-')[0],
                                         'duration': episode['duration'],
@@ -216,5 +228,5 @@ class Uzg:
 
             item = post
             item['label'] = titelnaam
-            item['video']['title'] = titelnaam
+            #item['video']['title'] = titelnaam
             return item


### PR DESCRIPTION
uzg.py:  Toont titels bij afleveringen ipv generieke programma naam en voegt omschrijving van aflevering toe (indien aanwezig) 
  
addon.py: enable viewtype Media info zodat plot/omschrijving van aflevering ook getoont kan worden (indien gewenst)