### PR TITLE
Return empty list

### DIFF
--- a/resources/lib/uzg.py
+++ b/resources/lib/uzg.py
@@ -42,7 +42,7 @@ class Uzg:
         elif action == 'Zoeken':
             if text:
                 return self.queryItems.getItems(text)
-            return List()
+            return []
         elif action == 'episodesSeason':
             return self.episodesOfSeasonItems.getItems(guid)
         elif action == 'episodesSerie':


### PR DESCRIPTION
Hoi! Een hele kleine bugfix. `typing.List` kan niet los gebruikt worden, maar is vooral bedoeld voor type hints.

Voor een lege lijst kan je `list()` of `[]` gebruiken.

```
>>> from typing import List
>>> List()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    List()
  File "/usr/local/Cellar/python@3.12/3.12.1/Frameworks/Python.framework/Version
s/3.12/lib/python3.12/typing.py", line 1138, in __call__
    raise TypeError(f"Type {self._name} cannot be instantiated; "
TypeError: Type List cannot be instantiated; use list() instead
```